### PR TITLE
GitHub CI Docker Compose Update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Build image
-        run: docker-compose build
+        run: docker compose build
       - name: Run plugin
-        run: docker-compose up
+        run: docker compose up
       - name: Extract coverage data
         run: |
           docker create --name test quay.io/arcalot/arcaflow-plugin-minio:latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,7 +8,7 @@ on:
       - published
 jobs:
   act:
-    uses: arcalot/arcaflow-container-toolkit/.github/workflows/reusable_workflow.yaml@wf-build-platform
+    uses: arcalot/arcaflow-container-toolkit/.github/workflows/reusable_workflow.yaml@main
     with:
       image_name: ${{ github.event.repository.name }}
       image_tag: 'latest'

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,9 +16,6 @@ jobs:
       QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-    environment: 
-      # the minio plugin is currently not ready for other cpu architectures
-      BUILD_PLATFORMS: linux/amd64
 
   docsgen:
     needs: act

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,7 +16,7 @@ jobs:
       QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-    env: 
+    environment: 
       # the minio plugin is currently not ready for other cpu architectures
       BUILD_PLATFORMS: linux/amd64
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -8,14 +8,17 @@ on:
       - published
 jobs:
   act:
-    uses: arcalot/arcaflow-container-toolkit/.github/workflows/reusable_workflow.yaml@main
+    uses: arcalot/arcaflow-container-toolkit/.github/workflows/reusable_workflow.yaml@wf-build-platform
     with:
       image_name: ${{ github.event.repository.name }}
       image_tag: 'latest'
+      # the minio plugin is currently not ready for other cpu architectures
+      build_platforms: linux/amd64
     secrets:
       QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      
 
   docsgen:
     needs: act

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -16,6 +16,9 @@ jobs:
       QUAY_NAMESPACE: ${{ secrets.QUAY_NAMESPACE }}
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+    env: 
+      # the minio plugin is currently not ready for other cpu architectures
+      BUILD_PLATFORMS: linux/amd64
 
   docsgen:
     needs: act

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG package=arcaflow_plugin_minio
 # STAGE 1 -- Build module dependencies and run tests
 # The 'poetry' and 'coverage' modules are installed and verson-controlled in the
 # quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase image to limit drift
-FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase:0.4.0 as build
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase:0.4.2 as build
 ARG package
 RUN dnf -y install https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20230629051228.0.0.x86_64.rpm
 
@@ -26,7 +26,7 @@ RUN python -m coverage run tests/test_${package}.py \
 
 
 # STAGE 2 -- Build final plugin image
-FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:0.4.0
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:0.4.2
 ARG package
 RUN dnf -y install https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20230629051228.0.0.x86_64.rpm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG package=arcaflow_plugin_minio
 # STAGE 1 -- Build module dependencies and run tests
 # The 'poetry' and 'coverage' modules are installed and verson-controlled in the
 # quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase image to limit drift
-FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase:0.3.1@sha256:9767207e2de6597c4d6bd2345d137ac03661326734d4e6824840d270d3415e12 as build
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase:0.4.0 as build
 ARG package
 RUN dnf -y install https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20230629051228.0.0.x86_64.rpm
 
@@ -26,7 +26,7 @@ RUN python -m coverage run tests/test_${package}.py \
 
 
 # STAGE 2 -- Build final plugin image
-FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:0.3.1@sha256:0e9384416ad5dd8810c410a87c283ca29a368fc85592378b85261fce5f9ecbeb
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:0.4.0
 ARG package
 RUN dnf -y install https://dl.min.io/server/minio/release/linux-amd64/archive/minio-20230629051228.0.0.x86_64.rpm
 

--- a/README.md
+++ b/README.md
@@ -37,24 +37,24 @@ Runs the MinIO server and sets up a bucket
 <table><tbody>
 <tr><th>Type:</th><td><code>scope</code></td><tr><th>Root object:</th><td>InputParams</td></tr>
 <tr><th>Properties</th><td><details><summary>bucket_name (<code>string</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>bucket name</td></tr><tr><th>Description:</th><td>Name for object bucket</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>&#34;arca-bucket&#34;</code></pre></td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+                <table><tbody><tr><th>Name:</th><td>bucket name</td></tr><tr><th>Description:</th><td width="500">Name for object bucket</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>&#34;arca-bucket&#34;</code></pre></td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
             </details><details><summary>minio_password (<code>string</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>MinIO password</td></tr><tr><th>Description:</th><td>The MinIO server password</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+                <table><tbody><tr><th>Name:</th><td>MinIO password</td></tr><tr><th>Description:</th><td width="500">The MinIO server password</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
             </details><details><summary>minio_user (<code>string</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>MinIO username</td></tr><tr><th>Description:</th><td>The MinIO server username</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+                <table><tbody><tr><th>Name:</th><td>MinIO username</td></tr><tr><th>Description:</th><td width="500">The MinIO server username</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
             </details><details><summary>run_duration (<code>int</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>run duration</td></tr><tr><th>Description:</th><td>Time in seconds that the MinIO plugin runs before being forceably stopped</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>
+                <table><tbody><tr><th>Name:</th><td>run duration</td></tr><tr><th>Description:</th><td width="500">Time in seconds that the MinIO plugin runs before being forceably stopped</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>
 </tbody></table>
             </details></td></tr>
 <tr><td colspan="2"><details><summary><strong>Objects</strong></summary><details><summary>InputParams (<code>object</code>)</summary>
             <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>bucket_name (<code>string</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>bucket name</td></tr><tr><th>Description:</th><td>Name for object bucket</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>&#34;arca-bucket&#34;</code></pre></td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        <table><tbody><tr><th>Name:</th><td>bucket name</td></tr><tr><th>Description:</th><td width="500">Name for object bucket</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Default (JSON encoded):</th><td><pre><code>&#34;arca-bucket&#34;</code></pre></td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
         </details><details><summary>minio_password (<code>string</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>MinIO password</td></tr><tr><th>Description:</th><td>The MinIO server password</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        <table><tbody><tr><th>Name:</th><td>MinIO password</td></tr><tr><th>Description:</th><td width="500">The MinIO server password</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
         </details><details><summary>minio_user (<code>string</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>MinIO username</td></tr><tr><th>Description:</th><td>The MinIO server username</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        <table><tbody><tr><th>Name:</th><td>MinIO username</td></tr><tr><th>Description:</th><td width="500">The MinIO server username</td></tr><tr><th>Required:</th><td>No</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
         </details><details><summary>run_duration (<code>int</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>run duration</td></tr><tr><th>Description:</th><td>Time in seconds that the MinIO plugin runs before being forceably stopped</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>
+        <table><tbody><tr><th>Name:</th><td>run duration</td></tr><tr><th>Description:</th><td width="500">Time in seconds that the MinIO plugin runs before being forceably stopped</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>int</code></td>
 </tbody></table>
         </details></td></tr>
 </tbody></table>
@@ -84,15 +84,15 @@ Runs the MinIO server and sets up a bucket
 <table><tbody>
 <tr><th>Type:</th><td><code>scope</code></td><tr><th>Root object:</th><td>SuccessOutput</td></tr>
 <tr><th>Properties</th><td><details><summary>access_key (<code>string</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>access key</td></tr><tr><th>Description:</th><td>The MinIO server access key (user)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+                <table><tbody><tr><th>Name:</th><td>access key</td></tr><tr><th>Description:</th><td width="500">The MinIO server access key (user)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
             </details><details><summary>secret_key (<code>string</code>)</summary>
-                <table><tbody><tr><th>Name:</th><td>secret key</td></tr><tr><th>Description:</th><td>The MinIO server access secret (password)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+                <table><tbody><tr><th>Name:</th><td>secret key</td></tr><tr><th>Description:</th><td width="500">The MinIO server access secret (password)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
             </details></td></tr>
 <tr><td colspan="2"><details><summary><strong>Objects</strong></summary><details><summary>SuccessOutput (<code>object</code>)</summary>
             <table><tbody><tr><th>Type:</th><td><code>object</code></td><tr><th>Properties</th><td><details><summary>access_key (<code>string</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>access key</td></tr><tr><th>Description:</th><td>The MinIO server access key (user)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        <table><tbody><tr><th>Name:</th><td>access key</td></tr><tr><th>Description:</th><td width="500">The MinIO server access key (user)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
         </details><details><summary>secret_key (<code>string</code>)</summary>
-        <table><tbody><tr><th>Name:</th><td>secret key</td></tr><tr><th>Description:</th><td>The MinIO server access secret (password)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
+        <table><tbody><tr><th>Name:</th><td>secret key</td></tr><tr><th>Description:</th><td width="500">The MinIO server access secret (password)</td></tr><tr><th>Required:</th><td>Yes</td></tr><tr><th>Type:</th><td><code>string</code></td></tbody></table>
         </details></td></tr>
 </tbody></table>
         </details></details></td></tr>


### PR DESCRIPTION
## Changes introduced with this PR

- Changes to fix removed `docker-compose` behavior in GitHub CI Runner computing environment
- Update arcaflow plugin sdk base image
- Pass `amd64` as the only platform to build with `buildah`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).